### PR TITLE
Add DISABLE_CUDA_GRAPHS env flag to disable NeMo RNNT CUDA graph decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Use `.env.example` as the template. Common settings:
 - `VAD_ENERGY_ACTIVE_SKIP`
 - `VAD_UNIFORM_CHUNK_S`
 - `VAD_UNIFORM_OVERLAP_S`
+- `DISABLE_CUDA_GRAPHS` (1 to disable NeMo RNNT CUDA graph decoding)
 
 See `docs/api.md` for detailed VAD/energy-gate behavior and defaults.
 

--- a/api.py
+++ b/api.py
@@ -42,6 +42,61 @@ def _get_env_float(name: str, default: str) -> float:
     return float(os.getenv(name, default))
 
 
+def _get_env_bool(name: str, default: str) -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _disable_cuda_graphs(asr_model, verbose: bool = False) -> bool:
+    disabled = False
+    if hasattr(asr_model, "cfg") and hasattr(asr_model.cfg, "decoding"):
+        if hasattr(asr_model.cfg.decoding, "greedy"):
+            from omegaconf import open_dict
+
+            with open_dict(asr_model.cfg.decoding.greedy):
+                asr_model.cfg.decoding.greedy.use_cuda_graph_decoder = False
+                if verbose:
+                    print("  Disabled CUDA graphs in cfg.decoding.greedy")
+                disabled = True
+
+    if hasattr(asr_model, "decoding") and hasattr(asr_model.decoding, "decoding"):
+        dc = asr_model.decoding.decoding
+        if hasattr(dc, "use_cuda_graph_decoder"):
+            dc.use_cuda_graph_decoder = False
+            if verbose:
+                print("  Disabled use_cuda_graph_decoder in decoding.decoding")
+            disabled = True
+        if hasattr(dc, "decoding_computer"):
+            dcomp = dc.decoding_computer
+            if hasattr(dcomp, "allow_cuda_graphs"):
+                dcomp.allow_cuda_graphs = False
+            if hasattr(dcomp, "disable_cuda_graphs"):
+                dcomp.disable_cuda_graphs()
+            if hasattr(dcomp, "cuda_graphs_mode"):
+                dcomp.cuda_graphs_mode = None
+            if verbose:
+                print("  Disabled CUDA graphs in decoding_computer")
+            disabled = True
+
+    for attr_name in ["joint", "joint_0", "joint_1", "joint_2", "joint_3"]:
+        if hasattr(asr_model, attr_name):
+            joint = getattr(asr_model, attr_name)
+            if hasattr(joint, "decoding") and hasattr(joint.decoding, "decoding"):
+                jdc = joint.decoding.decoding
+                if hasattr(jdc, "use_cuda_graph_decoder"):
+                    jdc.use_cuda_graph_decoder = False
+                if hasattr(jdc, "decoding_computer"):
+                    jdcomp = jdc.decoding_computer
+                    if hasattr(jdcomp, "allow_cuda_graphs"):
+                        jdcomp.allow_cuda_graphs = False
+                    if hasattr(jdcomp, "cuda_graphs_mode"):
+                        jdcomp.cuda_graphs_mode = None
+                if verbose:
+                    print(f"  Disabled CUDA graphs in {attr_name}")
+                disabled = True
+
+    return disabled
+
+
 def cuda_mem():
     if not torch.cuda.is_available():
         return {}
@@ -146,6 +201,9 @@ def _startup_load_model() -> None:
     asr_model = nemo_asr.models.ASRModel.from_pretrained(model_name=MODEL_NAME)
     asr_model = asr_model.to(device)
     _patch_transcribe_dataloader_no_lhotse(asr_model)
+    if _get_env_bool("DISABLE_CUDA_GRAPHS", "0"):
+        if _disable_cuda_graphs(asr_model, verbose=True):
+            print("  CUDA graphs disabled for decoding")
 
     # Warmup to amortize first-request overhead.
     dummy = torch.zeros(16000, dtype=torch.float32)

--- a/docs/api.md
+++ b/docs/api.md
@@ -198,6 +198,7 @@ If `chunk_only=true`, the endpoint skips ASR and returns VAD chunk metadata:
 - `DIARIZE_EMPTY_CACHE=1` runs `gc.collect()` after diarization and resets CUDA peak stats (model weights remain resident).
 - `DIARIZE_TF32=1` enables TF32 in CUDA matmul/cudnn for diarization to improve throughput at the cost of strict determinism.
 - Recommendation: keep `DIARIZE_TF32=0` for now; we did not see a consistent speedup.
+- `DISABLE_CUDA_GRAPHS=1` disables NeMo RNNT CUDA graph decoding to mitigate intermittent CUDA illegal memory access errors.
 - Energy gate fix validated via an in‑container 1s silence test using `run_vad_chunks_in_memory_from_waveform`.
 
 ## Recent benchmarks


### PR DESCRIPTION
### Motivation
- Provide an opt-out for NeMo RNNT CUDA graph decoding to mitigate intermittent CUDA illegal memory access errors observed in some GPU/runtime configurations.

### Description
- Add `_get_env_bool` utility to parse boolean environment flags.
- Implement `_disable_cuda_graphs(asr_model, verbose)` which disables `use_cuda_graph_decoder` and related CUDA-graph flags at the model config, decoding, decoding_computer, and joint-decoder levels.
- Invoke the disable path during ASR startup when `DISABLE_CUDA_GRAPHS` is enabled in the environment.
- Document the new `DISABLE_CUDA_GRAPHS` environment flag in `README.md` and `docs/api.md`.

### Testing
- Ran `python -m pytest` and all unit tests passed: `13 passed in 14.17s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ab72df088321a0f5c34df3d500c6)